### PR TITLE
Sister as function instead of field

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -118,7 +118,6 @@ template <typename captype, typename tcaptype, typename flowtype>
 		for (a=arcs; a<arc_last; a++)
 		{
 			if (a->next) a->next = (arc*) ((char*)a->next + (((char*) arcs) - ((char*) arcs_old)));
-			a->sister = (arc*) ((char*)a->sister + (((char*) arcs) - ((char*) arcs_old)));
 		}
 	}
 }

--- a/graph.h
+++ b/graph.h
@@ -178,6 +178,7 @@ public:
 	typedef arc* arc_id;
 	arc_id get_first_arc();
 	arc_id get_next_arc(arc_id a);
+	arc_id get_sister_arc(arc_id a);
 
 	// other functions for reading graph structure
 	int get_node_num() { return node_num; }
@@ -304,7 +305,6 @@ private:
 	{
 		node		*head;		// node the arc points to
 		arc			*next;		// next arc with the same originating node
-		arc			*sister;	// reverse arc
 
 		captype		r_cap;		// residual capacity
 	};
@@ -424,8 +424,6 @@ template <typename captype, typename tcaptype, typename flowtype>
 	node* i = nodes + _i;
 	node* j = nodes + _j;
 
-	a -> sister = a_rev;
-	a_rev -> sister = a;
 	a -> next = i -> first;
 	i -> first = a;
 	a_rev -> next = j -> first;
@@ -452,7 +450,7 @@ template <typename captype, typename tcaptype, typename flowtype>
 	inline void Graph<captype,tcaptype,flowtype>::get_arc_ends(arc* a, node_id& i, node_id& j)
 {
 	assert(a >= arcs && a < arc_last);
-	i = (node_id) (a->sister->head - nodes);
+	i = (node_id) (get_sister_arc(a)->head - nodes);
 	j = (node_id) (a->head - nodes);
 }
 
@@ -513,5 +511,16 @@ template <typename captype, typename tcaptype, typename flowtype>
 	i->is_marked = true;
 }
 
+template <typename captype, typename tcaptype, typename flowtype> 
+	inline typename Graph<captype,tcaptype,flowtype>::arc* Graph<captype,tcaptype,flowtype>::get_sister_arc(arc* a) 
+{
+	// Sisters are always ajacent.
+	// We calculate the arc number. If it's even the sister is next. Uneven the sister i previous.
+	if (((a - arcs)) % 2 == 0) {
+		return a + 1;
+	} else {
+		return a - 1;
+	}
+}
 
 #endif

--- a/graph.h
+++ b/graph.h
@@ -516,11 +516,7 @@ template <typename captype, typename tcaptype, typename flowtype>
 {
 	// Sisters are always ajacent.
 	// We calculate the arc number. If it's even the sister is next. Uneven the sister i previous.
-	if (((a - arcs)) % 2 == 0) {
-		return a + 1;
-	} else {
-		return a - 1;
-	}
+	return a + 1 - 2 * ((a - arcs) % 2);
 }
 
 #endif

--- a/graph.h
+++ b/graph.h
@@ -514,7 +514,7 @@ template <typename captype, typename tcaptype, typename flowtype>
 template <typename captype, typename tcaptype, typename flowtype> 
 	inline typename Graph<captype,tcaptype,flowtype>::arc* Graph<captype,tcaptype,flowtype>::get_sister_arc(arc* a) 
 {
-	// Sisters are always ajacent.
+	// Sisters are always adjacent.
 	// We calculate the arc number. If it's even the sister is next. Uneven the sister i previous.
 	return a + 1 - 2 * ((a - arcs) % 2);
 }


### PR DESCRIPTION
Removed the ```sister``` struct field and using a function instead of getting the sister arc. This reduces the struct size of the ```arc``` with at least 25%, which improves overall performance and memory footprint.